### PR TITLE
API request language modified to path format instead of passing as arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 Changelog
 =================================
+This changelog references the relevant changes done between versions.
 
-## [1.0.0] - (2018-03-08)
-### Added
-- A problem was found when retrieving categories and tags from the WP API: English data was not being appended in the _embed
-field while in Spanish worked properly. As result, those data was not being shown in the pages.
+- **[1.0.0] - (2018-03-08)**
+    - A problem was found when retrieving categories and tags from the WP API: English data was not being appended in the *_embed*
+    field while in Spanish worked properly. As result, those data was not being shown in the pages. The change implies to
+    modify the WPML configuration at "WPML > Language URL Format" to "Different Languages in the directories" and check the
+    "Use the directory for the default language" field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ Changelog
 =================================
 This changelog references the relevant changes done between versions.
 
-- **[1.0.0] - (2018-03-08)**
+- **[0.7.0] - (2018-03-08)**
     - A problem was found when retrieving categories and tags from the WP API: English data was not being appended in the *_embed*
     field while in Spanish worked properly. As result, those data was not being shown in the pages. The change implies to
     modify the WPML configuration at "WPML > Language URL Format" to "Different Languages in the directories" and check the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+Changelog
+=================================
+
+## [1.0.0] - (2018-03-08)
+### Added
+- A problem was found when retrieving categories and tags from the WP API: English data was not being appended in the _embed
+field while in Spanish worked properly. As result, those data was not being shown in the pages.

--- a/src/WordPressApiClient/Client.php
+++ b/src/WordPressApiClient/Client.php
@@ -36,7 +36,7 @@ class Client
         $path = '/wp-json/wp/v2/%s?per_page=%d&page=%d&_embed';
 
         if ($lang) {
-            $path .= '&lang=' . $lang;
+            $path = '/' . $lang . $path;
         }
 
         $response = $this->client->request('GET', sprintf(
@@ -54,7 +54,7 @@ class Client
         $path = '/wp-json/wp/v2/%s?per_page=%d';
 
         if ($lang) {
-            $path .= '&lang=' . $lang;
+            $path = '/' . $lang . $path;
         }
 
         $response = $this->client->request('GET', sprintf(
@@ -71,7 +71,7 @@ class Client
         $path = '/wp-json/wp/v2/%s?%s&per_page=%d&page=%d&_embed';
 
         if ($lang) {
-            $path .= '&lang=' . $lang;
+            $path = '/' . $lang . $path;
         }
 
         $response = $this->client->request('GET', sprintf(
@@ -89,7 +89,7 @@ class Client
         $path = '/wp-json/wp/v2/%s?slug=%s&_embed';
 
         if ($lang) {
-            $path .= '&lang=' . $lang;
+            $path = '/' . $lang . $path;
         }
 
         $response = $this->client->request('GET', sprintf($this->domain . $path, $resourceType, $slug));
@@ -104,7 +104,7 @@ class Client
         $path = '/wp-json/wp/v2/%s?%s&per_page=%d&page=%d&_embed';
 
         if ($lang) {
-            $path .= '&lang=' . $lang;
+            $path = '/' . $lang . $path;
         }
 
         $response = $this->client->request('GET', sprintf(
@@ -125,7 +125,7 @@ class Client
         $path = '/wp-json/wp/v2/%s/%s?_embed';
 
         if ($lang) {
-            $path .= '&lang=' . $lang;
+            $path = '/' . $lang . $path;
         }
 
         $response = $this->client->request(
@@ -141,7 +141,7 @@ class Client
         $path = '/wp-json/wp-rest-api-sidebars/v1/%s/%s';
 
         if ($lang) {
-            $path .= '?lang=' . $lang;
+            $path = '/' . $lang . $path;
         }
 
         $response = $this->client->request('GET', sprintf($this->domain . $path, $resourceType, $id));


### PR DESCRIPTION
A problem was found when retrieving categories and tags from the WP API: English data was not being appended in the _embed field while in Spanish worked properly. As result, those data was not being shown in the pages.

The change implies to modify the WPML configuration at the Wordpress back-office as follows:

>**WPML > Language URL Format > Different Languages in the directories**
>  (X) Use the directory for the default language