### PR TITLE
DELETE resource API call implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog
 =================================
 This changelog references the relevant changes done between versions.
 
+- **[0.7.1] - (2018-03-19)**
+    - DELETE resource call implemented. 
+
 - **[0.7.0] - (2018-03-08)**
     - A problem was found when retrieving categories and tags from the WP API: English data was not being appended in the *_embed*
     field while in Spanish worked properly. As result, those data was not being shown in the pages. The change implies to

--- a/src/WordPressApiClient/Client.php
+++ b/src/WordPressApiClient/Client.php
@@ -171,4 +171,23 @@ class Client
 
         return $headers = ['auth' => [$this->applicationUser, $this->applicationPassword]];
     }
+
+    public function deleteResource(string $resourceType, string $lang, string $identifier)
+    {
+        $headers = $this->getAuthHeader();
+        $path = '/wp-json/wp/v2/%s/%s';
+
+        if ($lang) {
+            $path = '/' . $lang . $path;
+        }
+
+        $response = $this->client->request(
+            'DELETE',
+            sprintf($this->domain . $path, $resourceType, $identifier),
+            $headers
+        );
+        if (($errorCode = $response->getStatusCode()) !== 200) {
+            throw new DeleteRequestFailed("$errorCode returned by the server");
+        }
+    }
 }

--- a/src/WordPressApiClient/Exception/DeleteRequestFailed.php
+++ b/src/WordPressApiClient/Exception/DeleteRequestFailed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace LIN3S\WordPressApiClient\Exception;
+
+/*
+ * This file is part of the WordPressAPIClient project.
+ *
+ * Copyright (c) 2017-present LIN3S <info@lin3s.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+use Throwable;
+
+class DeleteRequestFailed extends \Exception
+{
+
+}


### PR DESCRIPTION
**DELETE** API call implemented for being able to remove resources. If the call fails, an exception with the error code as message is thrown.